### PR TITLE
MAIN - bytes are now aligned with android and version is returned as lower case.

### DIFF
--- a/src/lib/EHREncryption.js
+++ b/src/lib/EHREncryption.js
@@ -81,7 +81,7 @@ export async function encrypt(pubKey, toEncryptBytes) {
   try {
     const cipherKey = await encryptKeyIv(pubKey, key, iv);
     const data = await aes.encrypt(key, iv, toEncryptBytes);
-    return { cipherKey, data, version: "oaepgcm" };
+    return { cipherKey, data, version: "oeapgcm" };
   } catch (e) {
     throw new Error("EncryptionFailed");
   }

--- a/src/lib/EHREncryption.js
+++ b/src/lib/EHREncryption.js
@@ -81,7 +81,7 @@ export async function encrypt(pubKey, toEncryptBytes) {
   try {
     const cipherKey = await encryptKeyIv(pubKey, key, iv);
     const data = await aes.encrypt(key, iv, toEncryptBytes);
-    return { cipherKey, data, version: "OAEPGCM" };
+    return { cipherKey, data, version: "oaepgcm" };
   } catch (e) {
     throw new Error("EncryptionFailed");
   }

--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -17,7 +17,7 @@ export function arrayBufferToString(buffer) {
   return String.fromCharCode.apply(null, new Uint8Array(buffer));
 }
 
-export async function generateInitialVector(bytes = 12) {
+export async function generateInitialVector(bytes = 16) {
   return window.crypto.getRandomValues(new Uint8Array(bytes));
 }
 


### PR DESCRIPTION
Hello. Title says it all :) There was a but with android that bytes has to be 16 instead of 12. Also version is now returned in lowercase as there is no reason to be capital actually. `adam` and `britney` is lowercase anyway

I think the version has a typo. The algorithms are [oaep](https://en.wikipedia.org/wiki/Optimal_asymmetric_encryption_padding) but if thats true then it exist on both ios and android. Best I could do is let ppl know..