### PR TITLE
MAIN - Enable publishing to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
+      - persist_to_workspace:
+          root: ~/repo
+          paths: .
+
   build:
     docker:
       - image: circleci/node:8.11.1
@@ -29,21 +33,14 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+      - attach_workspace:
+          at: ~/repo
 
-      - run: npm install
       - run: npm run build:package
-      - run: ls ./dist
 
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+      - persist_to_workspace:
+          root: ~/repo
+          paths: .
 
   publish:
     docker:
@@ -52,16 +49,11 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+      - attach_workspace:
+          at: ~/repo
 
       # Update package.json version
       - run: npm version $CIRCLE_TAG && git push origin HEAD:master
-      - run: npm install
       - run: npm run build:package
       - run: npm run deploy:documentation
       - run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/repo/.npmrc
@@ -69,7 +61,7 @@ jobs:
 
 workflows:
   version: 2
-  test-build--publish:
+  test-build-publish:
     jobs:
       - test:
           filters:
@@ -77,11 +69,15 @@ workflows:
               ignore:
                 - master
       - build:
+          requires:
+            - test
           filters:
             branches:
               ignore:
                 - master
       - publish:
+          requires:
+            - build
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run: npm version $CIRCLE_TAG && git push origin HEAD:master
       - run: npm install
       - run: npm run build:package
-      - run: npm run build:documentation
+      - run: npm run deploy:documentation
       - run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/repo/.npmrc
       - run: npm publish --access public
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 .idea
 .DS_Store
-node_modules
+/node_modules
 
 # logs
 *.log
 
 # coverage
-coverage
+/coverage
 
 # dist
-dist
+/dist
 
 /out

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.DS_Store
 node_modules
 
 # logs

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A web crypto library used by Vivy GmbH for encryption/decryption in browser.
 ### Installation
 
 ```
-npm i krypt-web
+npm i @vivy/krypt-web
 ```
 
 ### Usage
@@ -53,8 +53,13 @@ async function myDecryptionModule(code, pin, data) {
 
 ### Deployment process
 
-We deploy the minified version of the code in a separate branch to keep our `master` branch clean from code that is not needed.
-To deploy use `npm run deploy` this will trigger a build and push the minified files to `minified-source` branch.
+`krypt-web` is deployed to npm, and new releases are deployed by CircleCI after creating a Github release.
+
+To create a new release:
+
+1. Ensure your changes are merged to master
+1. Create a new Github release with the correct name (Release x.x.x) and tag (x.x.x). Your release **must** include a description of the changes included in the release
+1. CircleCI will then pick up the new tag and automatically build, test and publish the new version.
 
 ### Running the tests
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   ],
   "scripts": {
     "build:package": "rimraf dist && webpack",
-    "deploy": "npm run build:package && git-directory-deploy --directory dist/ --branch minified-source  --message 'Builds minified krypt-web'",
-    "build:documentation": "jsdoc src/lib && git-directory-deploy --directory out/",
+    "deploy:documentation": "jsdoc src/lib && git-directory-deploy --directory out/",
     "linter:check": "eslint src/**/*.js",
     "test": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
     "test:watch": "karma start --auto-watch --browsers ChromeHeadless karma.conf.js"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,16 @@
 {
   "name": "@vivy/krypt-web",
   "version": "0.0.0",
+  "description": "Vivy GmbH crypto library used for encryption/decryption in browser",
   "private": false,
   "repository": {
     "type": "git",
-    "url": "git://github.com/UvitaTeam/krypt-web"
+    "url": "https://github.com/VivyTeam/krypt-web.git"
   },
-  "main": "dist/index.js",
+  "main": "dist/krypt-web.min.js",
   "license": "MIT",
   "files": [
-    "/dist",
-    "index.js",
-    "README.md"
+    "/dist"
   ],
   "scripts": {
     "build:package": "rimraf dist && webpack",


### PR DESCRIPTION
This PR prepares the repository for automatic publishing to npm as `@vivy/krypt-web` when a new tag is released. 

Changes: 
- Fixes the package.json to use the correct values to files etc
- removes the old 'deploy' command which publishes to the `dist` branch as this wont be needed
- renamed `build:documentation` to `publish:documentation` as it's more fitting (publishes to gh pages)
- updates the gitignore - folders should have slashes otherwise nested folders, or even files with the same name will be ignored unintentionally
- Updates the readme with deployment instructions
- Updates the CircleCI build so that it reuses the workspace and does not `npm i` and build in every step 

How this was tested:
- I ran `npm pack` to create the package locally and installed that in a web app which uses `krypt-web` and ensured it was working. 
- I ran the circle ci build (test and build parts): https://circleci.com/gh/VivyTeam/krypt-web/421#build-parameters/containers/0 which has succeeded. 

@paschalidi looking forward to your feedback!
