### PR TITLE
MAIN - Ensure tags are build by CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,8 @@ workflows:
     jobs:
       - test:
           filters:
+            tags:
+              only: /\d+\.\d+\.\d+/
             branches:
               ignore:
                 - master
@@ -72,6 +74,8 @@ workflows:
           requires:
             - test
           filters:
+            tags:
+              only: /\d+\.\d+\.\d+/
             branches:
               ignore:
                 - master
@@ -80,6 +84,6 @@ workflows:
             - build
           filters:
             tags:
-              only: /.*/
+              only: /\d+\.\d+\.\d+/
             branches:
               ignore: /.*/


### PR DESCRIPTION
Currently:
The circle CI build and publish does not run when new tags are found

This is because in Circle CI will not run a job if any of its required jobs has filters that dont match. So, as per the Circle CI docs we need to add tag filters to all jobs: https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag

So, in this PR:
- Add tag filters to each stage
- Change the tag filter regex from accepting anything to only accepting `<number>.<number>.<number>`. Given this workflow publishes to npm with the circle CI tag name we should be a bit stricter here to ensure consistent tags, and that we can create _other_ tags that wont be published
