### PR TITLE
MAIN - Add deploy public key finger print so CircleCI can commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/repo
+      - add_ssh_keys:
+          fingerprints:
+            - "cf:9f:64:b3:02:33:f3:f9:13:9e:86:2c:40:f1:cf:66"
 
       # Update package.json version
       - run: npm version $CIRCLE_TAG && git push origin HEAD:master


### PR DESCRIPTION
This PR adds the `add_ssh_keys` step with the fingerprint of the read/write deploy public key to the Circle CI config. 

Without the CircleCI cannot make authenticate with github and push the version update commits to there repository. 

Another option is to set the `GH_TOKEN` environment variable but this is tied to individual github users rather than the project so it should be avoided. 

See: https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-github-user-key

