### PR TITLE
MAIN - Add checkout step to publish so git uses ssh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,13 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/repo
+
+      # Add the public deploy key from the repository
+      # and call checkout to ensure git uses ssh not https
       - add_ssh_keys:
           fingerprints:
             - "cf:9f:64:b3:02:33:f3:f9:13:9e:86:2c:40:f1:cf:66"
+      - checkout
 
       # Update package.json version
       - run: npm version $CIRCLE_TAG && git push origin HEAD:master


### PR DESCRIPTION
The circle CI checkout step includes steps that correctly configure git and trust the github.com domain. 

Without this we cannot run `git push` in the deploy steps. 

Seems to be common (vivy-components, this example: https://circleci.com/docs/2.0/deployment-integrations/#overview)

