### PR TITLE
Remove rimraf (unused dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "prettier": "^1.18.2",
     "pretty-quick": "^1.11.1",
     "raw-loader": "3.1.0",
-    "rimraf": "^2.6.3",
     "webpack": "^4.35.2"
   },
   "resolutions": {


### PR DESCRIPTION
While updating the dependencies it was found that this dependency is no longer needed